### PR TITLE
-ldl is only a requirement for linux

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,8 +43,11 @@ if(BUILD_TESTS)
     find_package(Threads)
     set(TARGET_LINK_LIB ${TARGET_LINK_LIB} ${CMAKE_THREAD_LIBS_INIT} ${TARGET_LINK})
 
+    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     find_library(DL_LIB dl)
     set(TARGET_LINK_LIB ${TARGET_LINK_LIB} ${DL_LIB})
+    endif()
+
     find_library(M_LIB m)
     set(TARGET_LINK_LIB ${TARGET_LINK_LIB} ${M_LIB})
 


### PR DESCRIPTION
Since -ldl is a linuxism, it's not need for other system (at least for *BSD)