### PR TITLE
Simplify libdl handling

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,12 +41,7 @@ if(BUILD_TESTS)
 
     
     find_package(Threads)
-    set(TARGET_LINK_LIB ${TARGET_LINK_LIB} ${CMAKE_THREAD_LIBS_INIT} ${TARGET_LINK})
-
-    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    find_library(DL_LIB dl)
-    set(TARGET_LINK_LIB ${TARGET_LINK_LIB} ${DL_LIB})
-    endif()
+    set(TARGET_LINK_LIB ${TARGET_LINK_LIB} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} ${TARGET_LINK})
 
     find_library(M_LIB m)
     set(TARGET_LINK_LIB ${TARGET_LINK_LIB} ${M_LIB})


### PR DESCRIPTION
CMake has builtin variable CMAKE_DL_LIBS which contains correct dynamic linker library (-ldl for linux, empty for *BSD etc.)