### PR TITLE
Polyline2D Geometry implemented

### DIFF
--- a/lib/cadgeometry.cpp
+++ b/lib/cadgeometry.cpp
@@ -362,12 +362,32 @@ CADVector& CADPolyline3D::getVertex( size_t index )
     return vertexes[index];
 }
 
+bool CADPolyline3D::isClosed() const
+{
+	return bClosed;
+}
+
+void CADPolyline3D::setClosed(bool state)
+{
+	bClosed = state;
+}
+
+bool CADPolyline3D::isSplined() const
+{
+	return bSplined;
+}
+
+void CADPolyline3D::setSplined(bool state)
+{
+	bSplined = state;
+}
+
 void CADPolyline3D::print() const
 {
     cout << "|------Polyline3D-----|" << endl;
     for( size_t i = 0; i < vertexes.size(); ++i )
     {
-        cout << "  #" << i << ". X: " << vertexes[i].getX() << ", Y: " << vertexes[i].getY() << std::endl;
+		cout << "  #" << i << ". X: " << vertexes[i].getX() << ", Y: " << vertexes[i].getY() << ", Z: " << vertexes[i].getZ() << std::endl;
     }
     cout << endl;
 }
@@ -387,6 +407,31 @@ void CADPolyline3D::transform( const Matrix& matrix )
 CADLWPolyline::CADLWPolyline()
 {
     geometryType = CADGeometry::LWPOLYLINE;
+}
+
+void CADLWPolyline::addVertex(const CADVector& vertex)
+{
+	vertexes.push_back(vertex);
+}
+
+size_t CADLWPolyline::getVertexCount() const
+{
+	return vertexes.size();
+}
+
+CADVector& CADLWPolyline::getVertex(size_t index)
+{
+	return vertexes[index];
+}
+
+bool CADLWPolyline::isClosed() const
+{
+	return bClosed;
+}
+
+void CADLWPolyline::setClosed(bool state)
+{
+	bClosed = state;
 }
 
 void CADLWPolyline::print() const
@@ -439,6 +484,11 @@ void CADLWPolyline::setWidths( const vector<pair<double, double> >& value )
     widths = value;
 }
 
+bool CADLWPolyline::hasBulges() const
+{
+	return hasNonZeroBulges;
+}
+
 vector<double> CADLWPolyline::getBulges() const
 {
     return bulges;
@@ -447,18 +497,159 @@ vector<double> CADLWPolyline::getBulges() const
 void CADLWPolyline::setBulges( const vector<double>& value )
 {
     bulges = value;
+	hasNonZeroBulges = false;
+	for ( size_t i = 0; i < bulges.size(); i++ )
+	{
+		if ( fabs( bulges[i] - 0.0 ) > std::numeric_limits<double>::epsilon() * 16 )
+		{
+			hasNonZeroBulges = true;
+			return;
+		}
+	}
 }
 
-bool CADLWPolyline::isClosed() const
+void CADLWPolyline::transform( const Matrix& matrix )
 {
-    return bClosed;
+	for (CADVector& vertex : vertexes)
+	{
+		vertex = matrix.multiply(vertex);
+	}
 }
 
-void CADLWPolyline::setClosed( bool state )
+//------------------------------------------------------------------------------
+// CADPolyline2D
+//------------------------------------------------------------------------------
+CADPolyline2D::CADPolyline2D()
 {
-    bClosed = state;
+	geometryType = CADGeometry::POLYLINE2D;
 }
 
+void CADPolyline2D::addVertex( const CADVector& vertex )
+{
+	vertexes.push_back(vertex);
+}
+
+size_t CADPolyline2D::getVertexCount() const
+{
+	return vertexes.size();
+}
+
+CADVector& CADPolyline2D::getVertex( size_t index )
+{
+	return vertexes[index];
+}
+
+bool CADPolyline2D::isClosed() const
+{
+	return bClosed;
+}
+
+void CADPolyline2D::setClosed( bool state )
+{
+	bClosed = state;
+}
+
+bool CADPolyline2D::isSplined() const
+{
+	return bSplined;
+}
+
+void CADPolyline2D::setSplined( bool state )
+{
+	bSplined = state;
+}
+
+double  CADPolyline2D::getStartSegWidth() const
+{
+	return dfStartWidth;
+}
+
+void CADPolyline2D::setStartSegWidth( double value )
+{
+	dfStartWidth = value;
+}
+
+double CADPolyline2D::getEndSegWidth() const
+{
+	return dfEndWidth;
+}
+
+void CADPolyline2D::setEndSegWidth( double value )
+{
+	dfEndWidth = value;
+}
+
+double CADPolyline2D::getElevation() const
+{
+	return elevation;
+}
+
+void CADPolyline2D::setElevation( double value )
+{
+	elevation = value;
+}
+
+CADVector CADPolyline2D::getVectExtrusion() const
+{
+	return vectExtrusion;
+}
+
+void CADPolyline2D::setVectExtrusion( const CADVector& value )
+{
+	vectExtrusion = value;
+}
+
+vector<pair<double, double> > CADPolyline2D::getWidths() const
+{
+	return widths;
+}
+
+void CADPolyline2D::setWidths( const vector<pair<double, double> >& value )
+{
+	widths = value;
+}
+
+bool CADPolyline2D::hasBulges() const
+{
+	return hasNonZeroBulges;
+}
+
+vector<double> CADPolyline2D::getBulges() const
+{
+	return bulges;
+}
+
+void CADPolyline2D::setBulges( const vector<double>& value )
+{
+	bulges = value;
+	hasNonZeroBulges = false;
+	for ( size_t i = 0; i < bulges.size(); i++ )
+	{
+		if ( fabs(bulges[i] - 0.0) > std::numeric_limits<double>::epsilon() * 16 )
+		{
+			hasNonZeroBulges = true;
+			return;
+		}
+	}	
+}
+
+void CADPolyline2D::print() const
+{
+	cout << "|------Polyline2D-----|" << endl;
+	for (size_t i = 0; i < vertexes.size(); ++i)
+	{
+		cout << "  #" << i << ". X: " << vertexes[i].getX() << ", Y: " << vertexes[i].getY() << std::endl;
+	}
+	cout << endl;
+}
+
+void CADPolyline2D::transform( const Matrix& matrix )
+{
+	for (CADVector& vertex : vertexes)
+	{
+		vertex = matrix.multiply(vertex);
+	}
+}
 
 //------------------------------------------------------------------------------
 // CADEllipse

--- a/lib/cadgeometry.h
+++ b/lib/cadgeometry.h
@@ -76,6 +76,7 @@ public:
         LWPOLYLINE,
         ELLIPSE,
         LINE,
+		POLYLINE2D,
         POLYLINE3D,
         TEXT,
         ARC,
@@ -176,6 +177,60 @@ protected:
 };
 
 /**
+* @brief Geometry class which represents Polyline 2D
+*/
+class CADPolyline2D : public CADGeometry
+{
+public:
+	CADPolyline2D();
+
+	void	   addVertex(const CADVector& vertex);
+	size_t	   getVertexCount() const;
+	CADVector& getVertex(size_t index);
+
+	bool isClosed() const;
+	void setClosed(bool state);
+
+	bool isSplined() const; // if splined there will be extra 2 vertexes at end defining end vector, if closed two at start also
+	void setSplined( bool state );
+
+	double getStartSegWidth() const;
+	void   setStartSegWidth( double value );
+
+	double getEndSegWidth() const;
+	void   setEndSegWidth( double value );
+
+	double getElevation() const;
+	void   setElevation( double value );
+
+	CADVector getVectExtrusion() const;
+	void      setVectExtrusion( const CADVector& value );
+
+	vector<pair<double, double> > getWidths() const;
+	void                          setWidths(const vector<pair<double, double> >& value);
+
+	bool		   hasBulges() const; // true if any vertexes have non zero bulges
+	vector<double> getBulges() const;
+	void           setBulges(const vector<double>& value);
+
+	virtual void print() const override;
+	virtual void transform( const Matrix& matrix ) override;
+
+protected:
+	bool						  bClosed;
+	bool						  bSplined;
+	double						  dfStartWidth;
+	double						  dfEndWidth;
+	double						  elevation;
+	CADVector					  vectExtrusion;
+	bool						  hasNonZeroBulges;
+	vector<double>				  bulges;
+	vector<pair<double, double> > widths; // start, end.
+	vector<CADVector>	          vertexes;
+};
+
+
+/**
  * @brief Geometry class which represents Polyline 3D
  */
 class CADPolyline3D : public CADGeometry
@@ -183,13 +238,22 @@ class CADPolyline3D : public CADGeometry
 public:
     CADPolyline3D();
 
-    void   addVertex( const CADVector& vertex );
-    size_t getVertexCount() const;
+    void       addVertex( const CADVector& vertex );
+    size_t	   getVertexCount() const;
     CADVector& getVertex( size_t index );
+
+	bool isClosed() const;
+	void setClosed( bool state );
+
+	bool isSplined() const; // if splined there will be extra 2 vertexes at end defining end direction, if closed two at start also
+	void setSplined( bool state );
 
     virtual void print() const override;
     virtual void transform( const Matrix& matrix ) override;
+
 protected:
+	bool			  bClosed;
+	bool			  bSplined;
     vector<CADVector> vertexes;
 };
 
@@ -197,10 +261,17 @@ protected:
  * @brief Geometry class which represents LWPolyline
  */
 
-class CADLWPolyline : public CADPolyline3D
+class CADLWPolyline : public CADGeometry
 {
 public:
     CADLWPolyline();
+
+	void       addVertex(const CADVector& vertex);
+	size_t	   getVertexCount() const;
+	CADVector& getVertex(size_t index);
+
+	bool isClosed() const;
+	void setClosed(bool state);
 
     double getConstWidth() const;
     void   setConstWidth( double value );
@@ -214,20 +285,22 @@ public:
     vector<pair<double, double> > getWidths() const;
     void                          setWidths( const vector<pair<double, double> >& value );
 
+	bool		   hasBulges() const; // true if any vertexes have non zero bulges
     vector<double> getBulges() const;
     void           setBulges( const vector<double>& value );
 
-    bool isClosed() const;
-    void setClosed( bool state );
-
     virtual void print() const override;
+	virtual void transform(const Matrix& matrix) override;
+
 protected:
-    bool                          bClosed;
+	bool						  bClosed;
     double                        constWidth;
     double                        elevation;
     CADVector                     vectExtrusion;
+	bool						  hasNonZeroBulges;
     vector<double>                bulges;
     vector<pair<double, double> > widths; // start, end.
+	vector<CADVector>		      vertexes;
 };
 
 /**

--- a/lib/cadobjects.h
+++ b/lib/cadobjects.h
@@ -438,13 +438,14 @@ public:
 class CADVertex2DObject : public CADEntityObject
 {
 public:
-              CADVertex2DObject();
-    CADVector vertPosition; // Z must be taken from 2d polyline elevation.
-    double    dfStartWidth;
-    double    dfEndWidth;
-    double    dfBulge;
-    long      nVertexID;
-    double    dfTangentDir;
+				  CADVertex2DObject();
+    unsigned char vFlags;
+    CADVector	  vertPosition; // Z must be taken from 2d polyline elevation.
+    double		  dfStartWidth;
+    double		  dfEndWidth;
+    double		  dfBulge;
+    long		  nVertexID;
+    double		  dfTangentDir;
 
 /* NOTES: Neither elevation nor thickness are present in the 2D VERTEX data.
  * Both should be taken from the 2D POLYLINE entity (15)
@@ -459,9 +460,9 @@ public:
 class CADVertex3DObject : public CADEntityObject
 {
 public:
-    CADVertex3DObject();
-
-    CADVector vertPosition;
+				  CADVertex3DObject();
+	unsigned char vFlags;
+    CADVector     vertPosition;
 };
 
 /**
@@ -504,10 +505,11 @@ public:
 class CADPolyline2DObject : public CADEntityObject
 {
 public:
-    CADPolyline2DObject();
-
+			  CADPolyline2DObject();
     short     dFlags;
     short     dCurveNSmoothSurfType;
+	bool	  bClosed;
+	bool	  bSplined;
     double    dfStartWidth;
     double    dfEndWidth;
     double    dfThickness;
@@ -527,15 +529,16 @@ public:
 class CADPolyline3DObject : public CADEntityObject
 {
 public:
-                  CADPolyline3DObject();
-    unsigned char SplinedFlags;
-    unsigned char ClosedFlags;
+                    CADPolyline3DObject();
+	unsigned char	SplinedFlags;
+	unsigned char	ClosedFlags;
+	bool		    bClosed;
+	bool			bSplined;
+    long			nObjectsOwned;
 
-    long nObjectsOwned;
+    CADHandleArray	hVertexes; // content really depends on DWG version.
 
-    CADHandleArray hVertexes; // content really depends on DWG version.
-
-    CADHandle hSeqend;
+	CADHandle       hSeqend;
 };
 
 /**

--- a/lib/dwg/r2000.h
+++ b/lib/dwg/r2000.h
@@ -109,6 +109,8 @@ protected:
                                         size_t& nBitOffsetFromStart );
     CADTextObject            * getText( long dObjectSize, CADCommonED stCommonEntityData, const char * pabyInput,
                                         size_t& nBitOffsetFromStart );
+	CADVertex2DObject        * getVertex2D(long dObjectSize, CADCommonED stCommonEntityData, const char * pabyInput,
+											size_t& nBitOffsetFromStart);
     CADVertex3DObject        * getVertex3D( long dObjectSize, CADCommonED stCommonEntityData, const char * pabyInput,
                                             size_t& nBitOffsetFromStart );
     CADCircleObject          * getCircle( long dObjectSize, CADCommonED stCommonEntityData, const char * pabyInput,


### PR DESCRIPTION
- Polyline2D geometry support added
- Polylines (2D & 3D): When reading vertexes, skip Curve Tangent and Spline Frame vertexes so geometry appears as per AutoCAD
- Polylines (LW & 2D): Added HasBulges() property for checking if arc sections are present
- Polyline3D Closed() property added