### PR TITLE
Fix fabs not declared

### DIFF
--- a/lib/dwg/r2000.cpp
+++ b/lib/dwg/r2000.cpp
@@ -38,6 +38,7 @@
 #include <cstring>
 #include <cassert>
 #include <memory>
+#include <math.h>
 
 #ifdef __APPLE__
 

--- a/lib/dwg/r2000.cpp
+++ b/lib/dwg/r2000.cpp
@@ -38,7 +38,7 @@
 #include <cstring>
 #include <cassert>
 #include <memory>
-#include <math.h>
+#include <cmath>
 
 #ifdef __APPLE__
 
@@ -2051,8 +2051,8 @@ CADVertex2DObject * DWGFileR2000::getVertex2D( long dObjectSize, CADCommonED stC
 	vertex->dfStartWidth = ReadBITDOUBLE( pabyInput, nBitOffsetFromStart );
 	if (vertex->dfStartWidth < 0) // if negative, abs start value is applicable for both start and end
 	{
-		vertex->dfStartWidth = fabs( vertex->dfStartWidth );
-		vertex->dfEndWidth = fabs(vertex->dfStartWidth);
+		vertex->dfStartWidth = std::fabs( vertex->dfStartWidth );
+		vertex->dfEndWidth = std::fabs(vertex->dfStartWidth);
 	}
 	else
 		vertex->dfEndWidth = ReadBITDOUBLE(pabyInput, nBitOffsetFromStart);


### PR DESCRIPTION
Scanning dependencies of target dwg
[ 12%] Building CXX object lib/dwg/CMakeFiles/dwg.dir/r2000.cpp.o
libopencad/lib/dwg/r2000.cpp: Dans la fonction membre « CADVertex2DObject* DWGFileR2000::getVertex2D(long int, CADCommonED, const char*, size_t&) »:
libopencad/lib/dwg/r2000.cpp:2053:53: erreur : « fabs » was not declared in this scope
   vertex->dfStartWidth = fabs( vertex->dfStartWidth );
                                                     ^
make[2]: *** [lib/dwg/CMakeFiles/dwg.dir/build.make:87: lib/dwg/CMakeFiles/dwg.dir/r2000.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:175: lib/dwg/CMakeFiles/dwg.dir/all] Error 2
make: *** [Makefile:139: all] Error 2
