### PR TITLE
Misc. source comment typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All you have to do now - is to link library with your project, and include assoc
 
 ### Library sources inclusion way
 
-All you have to do is to lib/ directory to your project file tree, thats actually it.
+All you have to do is to lib/ directory to your project file tree, that's actually it.
 
 ### Usage example
 

--- a/lib/cadfile.h
+++ b/lib/cadfile.h
@@ -39,7 +39,7 @@
 #include <string>
 
 /**
- * @brief The abstact CAD file class
+ * @brief The abstract CAD file class
  */
 class OCAD_EXTERN CADFile
 {

--- a/lib/cadgeometry.h
+++ b/lib/cadgeometry.h
@@ -118,7 +118,7 @@ protected:
 };
 
 /**
- * @brief Geometry class which represents Unhandled geometry (means that library cant read it yet)
+ * @brief Geometry class which represents Unhandled geometry (means that library can't read it yet)
  */
 class CADUnknown : public CADGeometry
 {

--- a/lib/cadheader.h
+++ b/lib/cadheader.h
@@ -340,7 +340,7 @@ public:
                               0 = Off
                               1 = On */
         DRAGVS, /**< Hard-pointer ID to visual style while creating 3D
-                              solid primitives. The defualt value is NULL */
+                              solid primitives. The default value is NULL */
         DWGCODEPAGE, /**< Drawing code page; set to the system code page
                               when a new drawing is created, but not otherwise
                               maintained by AutoCAD */

--- a/lib/cadlayer.h
+++ b/lib/cadlayer.h
@@ -76,7 +76,7 @@ public:
 
     unordered_set<string> getAttributesTags();
 
-    // cadinserthandle is 0 by default because if entity isnt a part of custom block - its a part of ModelSpace block.
+    // cadinserthandle is 0 by default because if entity isn't a part of custom block - it's a part of ModelSpace block.
     void addHandle( long handle, enum CADObject::ObjectType type, long cadinserthandle = 0 );
 
     size_t getGeometryCount() const;
@@ -105,7 +105,7 @@ protected:
 
     vector<CADObject::ObjectType>           geometryTypes; // FIXME: replace with hashset would be perfect
     unordered_set<string>                   attributesNames;
-    vector<pair<long, long> >               geometryHandles; // second param is CADInsert handle, 0 if its not a geometry in block ref.
+    vector<pair<long, long> >               geometryHandles; // second param is CADInsert handle, 0 if it's not a geometry in block ref.
     vector<long>                            imageHandles;
     vector<pair<long, map<string, long> > > geometryAttributes;
     map<long, Matrix>                       transformations;

--- a/lib/cadobjects.h
+++ b/lib/cadobjects.h
@@ -37,7 +37,7 @@
 using namespace std;
 
 /*
- * @brief Class which basicly implements implements 3D vertex
+ * @brief Class which basically implements 3D vertex
  */
 class CADVector
 {
@@ -170,7 +170,7 @@ public:
         ACDBPLACEHOLDER      = 0x50,         // 80
         VBA_PROJECT          = 0x51,             // 81
         LAYOUT               = 0x52,                  // 82
-        // Codes below arent fixed, libopencad uses it for reading, in writing it will be different!
+        // Codes below aren't fixed, libopencad uses it for reading, in writing it will be different!
         CELLSTYLEMAP         = 0x53,            // 83
         DBCOLOR              = 0x54,                 // 84
         DICTIONARYVAR        = 0x55,           // 85
@@ -594,7 +594,7 @@ public:
     CADEedArray    aEED;
     long           nNumReactors;
     bool           bNoXDictionaryPresent;
-    long           nNumEntries; // doesnt count MODELSPACE and PAPERSPACE
+    long           nNumEntries; // doesn't count MODELSPACE and PAPERSPACE
     CADHandle      hNull;
     CADHandle      hXDictionary;
     CADHandleArray hBlocks; // ends with modelspace and paperspace handles.
@@ -709,7 +709,7 @@ public:
     CADEedArray    aEED;
     long           nNumReactors;
     bool           bNoXDictionaryPresent;
-    long           nNumEntries; // doesnt count BYBLOCK / BYLAYER.
+    long           nNumEntries; // doesn't count BYBLOCK / BYLAYER.
     CADHandle      hNull;
     CADHandle      hXDictionary;
     CADHandleArray hLTypes;

--- a/lib/dwg/io.cpp
+++ b/lib/dwg/io.cpp
@@ -384,9 +384,9 @@ long ReadUMCHAR( const char * pabyInput, size_t& nBitOffsetFromStart )
         aMCharBytes[i] &= binary(01111111);
     }
 
-    // TODO: this code doesnt cover case when char.bytescount > 3, but its
+    // TODO: this code doesn't cover case when char.bytescount > 3, but it's
     //       possible on large files.
-    // I just cant write an algorithm that does this.
+    // I just can't write an algorithm that does this.
     switch( MCharBytesCount )
     {
         case 1:
@@ -467,9 +467,9 @@ long ReadMCHAR( const char * pabyInput, size_t& nBitOffsetFromStart )
         aMCharBytes[i] &= binary(01111111);
     }
 
-    // TODO: this code doesnt cover case when char.bytescount > 3, but its
+    // TODO: this code doesn't cover case when char.bytescount > 3, but it's
     //       possible on large files.
-    // I just cant write an algorithm that does this.
+    // I just can't write an algorithm that does this.
     switch( MCharBytesCount )
     {
         case 1:
@@ -524,8 +524,8 @@ unsigned int ReadMSHORT( const char * pabyInput, size_t& nBitOffsetFromStart )
     const char * pMShortFirstByte = pabyInput + nByteOffset;*/
     unsigned char aMShortBytes[8]; // 8 bytes is maximum.
 
-    // TODO: this function doesnot support MSHORTS longer than 4 bytes. ODA says
-    //       its impossible, but not sure.
+    // TODO: this function doesn't support MSHORTS longer than 4 bytes. ODA says
+    //       it's impossible, but not sure.
     size_t MShortBytesCount = 2;
     aMShortBytes[0] = ReadCHAR( pabyInput, nBitOffsetFromStart );
     aMShortBytes[1] = ReadCHAR( pabyInput, nBitOffsetFromStart );

--- a/lib/dwg/r2000.cpp
+++ b/lib/dwg/r2000.cpp
@@ -629,8 +629,7 @@ int DWGFileR2000::ReadHeader( OpenOptions eOptions )
     pFileIO->Read( pabyBuf, DWGSentinelLength );
     if( memcmp( pabyBuf, DWGHeaderVariablesEnd, DWGSentinelLength ) )
     {
-        DebugMsg( "File is corrupted (HEADERVARS section ending sentinel "
-                          "doesnt match.)" );
+        DebugMsg("File is corrupted (HEADERVARS section ending sentinel doesn't match.)");
 
         returnCode = CADErrorCodes::HEADER_SECTION_READ_FAILED;
     }
@@ -686,8 +685,7 @@ int DWGFileR2000::ReadClasses( enum OpenOptions eOptions )
         pFileIO->Read( buffer, DWGSentinelLength );
         if( memcmp( buffer, DWGDSClassesEnd, DWGSentinelLength ) )
         {
-            cerr << "File is corrupted (CLASSES section ending sentinel "
-                    "doesnt match.)\n";
+            cerr << "File is corrupted (CLASSES section ending sentinel doesn't match.)\n";
             return CADErrorCodes::CLASSES_SECTION_READ_FAILED;
         }
     }
@@ -710,8 +708,8 @@ int DWGFileR2000::CreateFileMap()
 
     mapObjects.clear();
 
-    // seek to the begining of the objects map
-    pFileIO->Seek( sectionLocatorRecords[2].dSeeker, CADFileIO::SeekOrigin::BEG );
+    // seek to the beginning of the objects map
+    pFileIO->Seek(sectionLocatorRecords[2].dSeeker, CADFileIO::SeekOrigin::BEG);
 
     while( true )
     {
@@ -845,7 +843,7 @@ CADObject * DWGFileR2000::GetObject( long dHandle, bool bHandlesOnly )
         stCommonEntityData.nInvisibility    = ReadBITSHORT( pabySectionContent, nBitOffsetFromStart );
         stCommonEntityData.nLineWeight      = ReadCHAR( pabySectionContent, nBitOffsetFromStart );
 
-        // Skip entitity-specific data, we dont need it if bHandlesOnly == true
+        // Skip entitity-specific data, we don't need it if bHandlesOnly == true
         if( bHandlesOnly == true )
         {
             return getEntity( dObjectType, dObjectSize, stCommonEntityData, pabySectionContent, nBitOffsetFromStart );
@@ -2637,7 +2635,7 @@ CADDictionaryObject * DWGFileR2000::getDictionary( long dObjectSize, const char 
 {
     /*
      * FIXME: ODA has a lot of mistypes in spec. for this objects,
-     * it doesnt work for now (error begins in handles stream).
+     * it doesn't work for now (error begins in handles stream).
      * Nonetheless, dictionary->sItemNames is 100% array,
      * not a single obj as pointer by their docs.
      */

--- a/lib/opencad.cpp
+++ b/lib/opencad.cpp
@@ -154,7 +154,7 @@ CADFileIO* GetDefaultFileIO( const char * pszFileName )
  * @brief IdentifyCADFile
  * @param pCADFileIO pointer to file in/out class
  * @return positive number for dwg version, negative for dxf version, 0 if error
- * occured
+ * occurred
  */
 int IdentifyCADFile( CADFileIO * pCADFileIO, bool bOwn )
 {


### PR DESCRIPTION
Found via `codespell` in downstream LibreCAD.