### PR TITLE
Fix build for MSVC

### DIFF
--- a/lib/opencad.h
+++ b/lib/opencad.h
@@ -59,13 +59,13 @@
 #      ifdef __GNUC__
 #        define OCAD_EXTERN extern __attribute__((dllexport))
 #      else        
-#        define OCAD_EXTERN extern __declspec(dllexport)
+#        define OCAD_EXTERN __declspec(dllexport)
 #      endif 
 #    else
 #      ifdef __GNUC__
 #        define OCAD_EXTERN extern __attribute__((dllimport))
 #      else        
-#        define OCAD_EXTERN extern __declspec(dllimport)
+#        define OCAD_EXTERN __declspec(dllimport)
 #      endif 
 #    endif
 #   else


### PR DESCRIPTION
Removed the abundand `extern` keyword in front of the `__declspec(dllimport)` and `__declspec(dllexport)` lines, which caused a delicate selection of 1600 of the finest unreadable error messages.

Note that this doesn't completely fix the build yet - but it reduces the amount of 1600 errors to 3.