### PR TITLE
Added limit lib to fix project building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 *.user
 /build*
 /inst
+cmake-build-debug

--- a/lib/cadobjects.cpp
+++ b/lib/cadobjects.cpp
@@ -31,8 +31,9 @@
 
 #include "cadobjects.h"
 
-#include <math.h>
+#include <cmath>
 #include <algorithm>
+#include <limits>
 
 //------------------------------------------------------------------------------
 // CADVector


### PR DESCRIPTION
**Problem:** While building project via cmake appears problem with log:
```c++
 error: ‘numeric_limits’ is not a member of ‘std’
   40 | #define EPSILON std::numeric_limits<double>::epsilon() * 16
      |                      ^~~~~~~~~~~~~~
``` 
**Solution:** Need to include additional lib for limits